### PR TITLE
Fix selinux context issue for var/log/tendrl directory

### DIFF
--- a/tendrl.fc
+++ b/tendrl.fc
@@ -12,4 +12,4 @@
 
 /var/lib/tendrl(/.*)?		gen_context(system_u:object_r:tendrl_var_lib_t,s0)
 
-/var/log/tendrl(/.*)?		gen_context(system_u:object_r:tendrl_log_t,s0)
+/var/log/tendrl/api(/.*)?	gen_context(system_u:object_r:tendrl_log_t,s0)


### PR DESCRIPTION
/var/log/tendrl is the directory where rsyslog and tendrl-api services
want to keep its log records. Currently tendrl-api creates this
directory and adds tendrl_log context to it using selinux-policy
which block rsyslog to access this directory.

Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>